### PR TITLE
Use indirect variable references in <SID>SetOption

### DIFF
--- a/plugin/now.vim
+++ b/plugin/now.vim
@@ -5,7 +5,7 @@
 " Option setting function defined
 function! <SID>SetOption(name, map) "{{{
   if !exists("g:NOW_" . a:name)
-    execute "silent! normal! :let g:NOW_" . a:name . " = '" . a:map . "'\r"
+    let {"g:NOW_" . a:name} = a:map
   endif
 endfunction "}}}
 " For each option, default value is set unless previously overridden in user's .vimrc


### PR DESCRIPTION
Function <SID>SetOption(name, map) is a helper that adds a prefix to a
variable name and sets its value.  Using `execute` and string
substitution has a side effect where Vim normally expects to display the
output from the evaluation, hence triggering the "Press ENTER ..."
effect.

Using curly braces to the same purpose avoids the eval behavior and
doesn't trigger the output-displaying affect.

from: http://vim.wikia.com/wiki/Scripting_-_Indirectly_Referencing_Variables

:help curly-braces-names

Solves Dalker/vim-now#1